### PR TITLE
Enable libSDL2_ttf, libSDL2_mixer on windows.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,4 +3,5 @@ BinDeps
 Cairo
 ColorTypes
 Compat
+DataStructures
 @osx Homebrew

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,9 +4,8 @@ using Compat
 @BinDeps.setup
 
 libSDL2 = library_dependency("libSDL2", aliases = ["sdl2", "libsdl2-2.0", "libSDL","SDL2"])
-# For now, these libraries don't work on Windows for some reason..
-libSDL2_ttf = library_dependency("libSDL2_ttf", aliases = ["SDL_ttf","SDL2_ttf"], os = :Darwin)
-libSDL2_mixer = library_dependency("libSDL2_mixer", aliases = ["SDL_mixer","SDL2_mixer"], os = :Darwin)
+libSDL2_ttf = library_dependency("libSDL2_ttf", aliases = ["SDL_ttf","SDL2_ttf"])
+libSDL2_mixer = library_dependency("libSDL2_mixer", aliases = ["SDL_mixer","SDL2_mixer"])
 
 if is_apple()
     using Homebrew
@@ -17,17 +16,32 @@ end
 
 
 if is_windows()
-    provides(Binaries, URI("https://www.libsdl.org/release/SDL2-2.0.7-win32-x64.zip"), libSDL2, unpacked_dir=".")
-    #provides(Binaries, URI("https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14-win32-x64.zip"), libSDL2_ttf, unpacked_dir=".")
-    #provides(Binaries, URI("https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2-win32-x64.zip"), libSDL2_mixer, unpacked_dir=".")
+    # HACK: Manually load SDL2.dll, since SDL2_ttf and SDL2_mixer won't load
+    # unless SDL2 is already loaded. As far as I can tell, there's no way to
+    # tell BinDeps about that kind of hard inter-library dependency.
+    Libdl.dlopen(joinpath(@__DIR__, "libSDL2", "SDL2.dll"))
+    provides(Binaries, URI("https://www.libsdl.org/release/SDL2-2.0.7-win32-x64.zip"), libSDL2, unpacked_dir=".", os = :Windows)
+    provides(Binaries, URI("https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14-win32-x64.zip"), libSDL2_ttf, unpacked_dir=".", os = :Windows)
+    provides(Binaries, URI("https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2-win32-x64.zip"), libSDL2_mixer, unpacked_dir=".", os = :Windows)
 end
 
 provides(AptGet, "libsdl2-2.0", libSDL2)
 provides(Yum, "SDL2", libSDL2)
 provides(Pacman, "sdl2", libSDL2)
 
+#OrderedDict(a...) = Dict(a...)
+
 @BinDeps.install Dict(
     "libSDL2" => "libSDL2",
     "libSDL2_ttf" => "libSDL2_ttf",
     "libSDL2_mixer" => "libSDL2_mixer",
 )
+
+if is_windows()
+    # HACK: Now, hilariously, reorder the @checked_lib lines to make sure SDL2 is first
+    deps_jl = joinpath(@__DIR__, "deps.jl")
+    depslines = readlines(deps_jl)
+    liblines = ismatch.(r"SDL2", depslines)
+    depslines[liblines] = sort(depslines[liblines])
+    write(deps_jl, join(depslines, "\n"))
+end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,8 +4,11 @@ using Compat
 @BinDeps.setup
 
 libSDL2 = library_dependency("libSDL2", aliases = ["sdl2", "libsdl2-2.0", "libSDL","SDL2"])
-libSDL2_ttf = library_dependency("libSDL2_ttf", aliases = ["SDL_ttf","SDL2_ttf"])
-libSDL2_mixer = library_dependency("libSDL2_mixer", aliases = ["SDL_mixer","SDL2_mixer"])
+if !is_windows()
+    # HACK: These definitions must come later for windows.
+    libSDL2_ttf = library_dependency("libSDL2_ttf", aliases = ["SDL_ttf","SDL2_ttf"])
+    libSDL2_mixer = library_dependency("libSDL2_mixer", aliases = ["SDL_mixer","SDL2_mixer"])
+end
 
 if is_apple()
     using Homebrew
@@ -14,34 +17,43 @@ if is_apple()
     provides(Homebrew.HB, "SDL2_mixer", libSDL2_mixer, os = :Darwin)
 end
 
-
-if is_windows()
-    # HACK: Manually load SDL2.dll, since SDL2_ttf and SDL2_mixer won't load
-    # unless SDL2 is already loaded. As far as I can tell, there's no way to
-    # tell BinDeps about that kind of hard inter-library dependency.
-    Libdl.dlopen(joinpath(@__DIR__, "libSDL2", "SDL2.dll"))
-    provides(Binaries, URI("https://www.libsdl.org/release/SDL2-2.0.7-win32-x64.zip"), libSDL2, unpacked_dir=".", os = :Windows)
-    provides(Binaries, URI("https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14-win32-x64.zip"), libSDL2_ttf, unpacked_dir=".", os = :Windows)
-    provides(Binaries, URI("https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2-win32-x64.zip"), libSDL2_mixer, unpacked_dir=".", os = :Windows)
-end
-
 provides(AptGet, "libsdl2-2.0", libSDL2)
 provides(Yum, "SDL2", libSDL2)
 provides(Pacman, "sdl2", libSDL2)
 
-#OrderedDict(a...) = Dict(a...)
-
-@BinDeps.install Dict(
-    "libSDL2" => "libSDL2",
-    "libSDL2_ttf" => "libSDL2_ttf",
-    "libSDL2_mixer" => "libSDL2_mixer",
-)
-
 if is_windows()
-    # HACK: Now, hilariously, reorder the @checked_lib lines to make sure SDL2 is first
+    # HACK: First, install just libSDL2, so that the other libs have access to it.
+    provides(Binaries, URI("https://www.libsdl.org/release/SDL2-2.0.7-win32-x64.zip"), libSDL2, unpacked_dir=".", os = :Windows)
+    @BinDeps.install Dict(
+        "libSDL2" => "libSDL2",
+    )
+    # Now that SDL2 is installed, we can install the extension libraries.
+    libSDL2_ttf = library_dependency("libSDL2_ttf", aliases = ["SDL_ttf","SDL2_ttf"])
+    libSDL2_mixer = library_dependency("libSDL2_mixer", aliases = ["SDL_mixer","SDL2_mixer"])
+    # HACK: In order to get them to pass validation, we have to manually load
+    # SDL2.dll, since SDL2_ttf and SDL2_mixer won't dlopen unless SDL2 is
+    # already opened. As far as I can tell, there's no way to tell BinDeps about
+    # that kind of hard inter-library dependency.
+    Libdl.dlopen(joinpath(@__DIR__, "libSDL2", "SDL2.dll"))
+    provides(Binaries, URI("https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14-win32-x64.zip"), libSDL2_ttf, unpacked_dir=".", os = :Windows)
+    provides(Binaries, URI("https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2-win32-x64.zip"), libSDL2_mixer, unpacked_dir=".", os = :Windows)
+    # Regenerate the deps.jl file with all three libs.
+    @BinDeps.install Dict(
+        "libSDL2" => "libSDL2",
+        "libSDL2_ttf" => "libSDL2_ttf",
+        "libSDL2_mixer" => "libSDL2_mixer",
+    )
+    # HACK: Finally, hilariously, reorder the @checked_lib lines to make sure
+    # SDL2 is loaded first at runtime.
     deps_jl = joinpath(@__DIR__, "deps.jl")
     depslines = readlines(deps_jl)
     liblines = ismatch.(r"SDL2", depslines)
     depslines[liblines] = sort(depslines[liblines])
     write(deps_jl, join(depslines, "\n"))
+else
+    @BinDeps.install Dict(
+        "libSDL2" => "libSDL2",
+        "libSDL2_ttf" => "libSDL2_ttf",
+        "libSDL2_mixer" => "libSDL2_mixer",
+    )
 end

--- a/src/SimpleDirectMediaLayer.jl
+++ b/src/SimpleDirectMediaLayer.jl
@@ -11,12 +11,10 @@ module SimpleDirectMediaLayer
     end
 
     include("lib/SDL.jl")
-    if is_apple()
-        include("lib/SDL_ttf.jl")
-        include("lib/SDL_mixer.jl")
+    include("lib/SDL_ttf.jl")
+    include("lib/SDL_mixer.jl")
 
-        export  TTF_Init, TTF_OpenFont, TTF_RenderText_Blended, TTF_SizeText
-    end
+    export  TTF_Init, TTF_OpenFont, TTF_RenderText_Blended, TTF_SizeText
 
     import Base.unsafe_convert
 
@@ -62,10 +60,8 @@ module SimpleDirectMediaLayer
         GL_SetAttribute(GL_MULTISAMPLEBUFFERS, 4)
         GL_SetAttribute(GL_MULTISAMPLESAMPLES, 4)
         Init(UInt32(INIT_VIDEO))
-        if is_apple()
-            TTF_Init()
-            Mix_OpenAudio(Int32(22050), UInt16(MIX_DEFAULT_FORMAT), Int32(2), Int32(1024) )
-        end
+        TTF_Init()
+        Mix_OpenAudio(Int32(22050), UInt16(MIX_DEFAULT_FORMAT), Int32(2), Int32(1024) )
     end
 
     function mouse_position()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,10 +4,8 @@ using Base.Test
 
 include("lib/SDL.jl")
 
-if is_apple()
-    include("lib/SDL_ttf.jl")
-    include("lib/SDL_mixer.jl")
-end
+include("lib/SDL_ttf.jl")
+include("lib/SDL_mixer.jl")
 
 # Integration tests
 @testset "example1" begin


### PR DESCRIPTION
Turn on TTF and Mixer support on Windows. Removes all `is_apple` /
`is_windows` checks everywhere except `build.jl`.

This should hopefully bring Mac and Windows to be equally supported! :)

--------------------------

Getting BinDeps to be happy required a few hacks.
On windows, SDL2_ttf.dll and SDL2_mixer.dll won't load unless SDL2.dll
is already loaded, and there doesn't seem to be a way to force BinDeps
to load them in-order. Fixing this required the following HACKs:
 - To fix `Pkg.build`: Manually `Libdl.dlopen(SDL2)` during build.jl, so
 that BinDeps can check that the other dll's work.
 - To fix runtime: Manually re-order the generated deps.jl to load the
 libs in the correct order.