### PR TITLE
Make audio example work with Julia 1.0

### DIFF
--- a/src/examples/audio_example/lesson11.jl
+++ b/src/examples/audio_example/lesson11.jl
@@ -1,24 +1,23 @@
 # This file transformed from Lazy Foo' Productions "Playing Sounds" tutorial:
 # http://lazyfoo.net/SDL_tutorials/lesson11/index.php
 
-cd(joinpath(Pkg.dir(),"SDL2/src/"))
-
-using SDL2
+using SimpleDirectMediaLayer
+const SDL2 = SimpleDirectMediaLayer
 
 SDL2.init()
 
 #Load the music
-aud_files = "examples/audio_example/"
+aud_files = dirname(@__FILE__)
 music = SDL2.Mix_LoadMUS( "$aud_files/beat.wav" );
+
 if (music == C_NULL)
-    #error
+    error("$aud_files/beat.wav not found.")
 end
 
 scratch = SDL2.Mix_LoadWAV( "$aud_files/scratch.wav" );
 high = SDL2.Mix_LoadWAV( "$aud_files/high.wav" );
 med = SDL2.Mix_LoadWAV( "$aud_files/medium.wav" );
 low = SDL2.Mix_LoadWAV( "$aud_files/low.wav" );
-
 
 SDL2.Mix_PlayChannel( Int32(-1), med, Int32(0) )
 SDL2.Mix_PlayMusic( music, Int32(-1) )


### PR DESCRIPTION
I found your nice SDL wrapper for Julia, and when trying it out on the latest version (1.0) found that the audio example did not work. These changes take care of that. Haven't tested it on older versions though, don't know if that is important to you.