### PR TITLE
Removing info line from keyboard event

### DIFF
--- a/src/SimpleDirectMediaLayer.jl
+++ b/src/SimpleDirectMediaLayer.jl
@@ -57,8 +57,6 @@ module SimpleDirectMediaLayer
         evtype = Event(t)
         evtype == nothing && return nothing
 
-        evtype == KeyboardEvent && info(ev)
-
         unsafe_load( Ptr{evtype}(pointer_from_objref(ev)) )
     end
 


### PR DESCRIPTION
This line does not seem necessary and actually seems to be broken